### PR TITLE
fix links

### DIFF
--- a/mkdocs/Configuration.md
+++ b/mkdocs/Configuration.md
@@ -8,7 +8,7 @@ If you want information on settings in paper.yml, spigot.yml, bukkit.yml and ser
 
 * [Spigot Configuration (spigot.yml)](https://www.spigotmc.org/wiki/spigot-configuration/)
 
-* [Paper Configuration (paper.yml)](https://docs.papermc.io/paper/reference/paper-yml)
+* [Paper Configuration (paper.yml)](https://docs.papermc.io/paper/reference/paper-global-configuration)
 
 ???+ warning "Warning"
     Configuration values change frequently at times. It is possible for the information here to be incomplete. If you cannot find what you’re looking for or think something may be wrong, Contact us through our [Discord]({{ social[0].link }}) server.

--- a/mkdocs/Installation.md
+++ b/mkdocs/Installation.md
@@ -1,1 +1,1 @@
-Since Purpur is a drop-in replacement for Paper (with no changes required), you can follow their [Getting Started](https://docs.papermc.io/paper/how-to/getting-started) guide to install Purpur.
+Since Purpur is a drop-in replacement for Paper (with no changes required), you can follow their [Getting Started](https://docs.papermc.io/paper/getting-started) guide to install Purpur.


### PR DESCRIPTION
I think maybe you switched to new papermc docs before it was ready :((

someone at the paper made change which breaks the links it 404!

This adds.