### PR TITLE
fix hyperlink in permissions

### DIFF
--- a/mkdocs/Permissions.md
+++ b/mkdocs/Permissions.md
@@ -143,7 +143,7 @@ Hex colors only register once a book has been signed
 ## purpur.anvil.color
 Requires enabling [`anvil.allow-colors`](../Configuration#allow-colors_1) in purpur.yml
 
-- Allows players to use legacy color codes in anvil. [`There is more information about colour codes on the Minecraft website.`](**https://minecraft.fandom.com/wiki/Formatting_codes**)
+- Allows players to use legacy color codes in anvil. [`There is more information about colour codes on the Minecraft website.`](https://minecraft.fandom.com/wiki/Formatting_codes)
 
 ## purpur.anvil.minimessage
 Requires enabling [`anvil.allow-minimessage`](../Configuration#use-mini-message) in purpur.yml


### PR DESCRIPTION
This PR fixes hyperlink not working as expected in [`Permissions.md`](https://github.com/PurpurMC/PurpurDocs/blob/main/mkdocs/Permissions.md?plain=1#L146)