### PR TITLE
Fix Paper issues link and Mojira link (#98)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ plugins:
       autolinks:
           - reference_prefix: MC-
             target_url: https://bugs.mojang.com/browse/MC-<num>
+          - reference_prefix: PaperMC/Paper#
+            target_url: https://github.com/PaperMC/Paper/issues/<num>
   - redirects:
       redirect_maps:
           'commands.md': 'purpur/commands.md'

--- a/mkdocs/purpur/configuration.md
+++ b/mkdocs/purpur/configuration.md
@@ -889,7 +889,7 @@ For a more clear explanation of the world settings section of the config, feel f
 * ##### deactivate-by-redstone
     - **default**: false
     - **description**: Allow spawners to be deactivated by redstone
-* ##### fix-mс-238526
+* ##### fix-mc-238526
     - **default**: false
     - **description**: Fix spawners not spawning water animals correctly; MC-238526
 #### sponge

--- a/mkdocs/purpur/configuration.md
+++ b/mkdocs/purpur/configuration.md
@@ -889,7 +889,7 @@ For a more clear explanation of the world settings section of the config, feel f
 * ##### deactivate-by-redstone
     - **default**: false
     - **description**: Allow spawners to be deactivated by redstone
-* ##### fix-mc-238526
+* ##### fix-mс-238526
     - **default**: false
     - **description**: Fix spawners not spawning water animals correctly; MC-238526
 #### sponge


### PR DESCRIPTION
Added to the mkdocs.yml that it automatically makes PaperMC/Paper be links to the issue/pr.
I fixed the Mojira link being in the header by putting a Cyrillic с (which looks like c but isn't c) into the header. It could be theoretically be solved differently but this is my first time using mkdocs 🤣 


Fixes #98