### PR TITLE
Corrected 'startup-commands' option name

### DIFF
--- a/mkdocs/purpur/configuration.md
+++ b/mkdocs/purpur/configuration.md
@@ -244,7 +244,7 @@ S  ·  ◈  ·  ◈  ·  ◈  ·  SW  ·  ◈  ·  ◈  ·  ◈  ·  W  ·  ◈ 
 - **default**: false
 - **description**: Set to true to register unused/hidden minecraft commands. The following commands become available (along with their `minecraft.command.<command_name>` permission counterpart): `debugconfig`, `serverpack`, `spawn_armor_trims`, `warden_spawn_tracker`, `debugmobspawning`, `debugpath`, `raid`, `resetchunks`, `test`. This list may or may not be incomplete depending on if they get removed or new ones get added in newer minecraft versions.
 
-### register-startup-commands
+### startup-commands
 Set the `Purpur.IReallyDontWantStartupCommands` system property to `true` to disable this feature.
 
 - **default**: []


### PR DESCRIPTION
I was called `register-startup-commands` in the docs, while in the server config it's just `startup-commands`.