### PR TITLE
these options should be off by default

### DIFF
--- a/mkdocs/purpur/configuration.md
+++ b/mkdocs/purpur/configuration.md
@@ -517,7 +517,7 @@ spider_eye:                # The food to edit
     - **default**: false
     - **description**: Allows the ability to increase enchantments passed their max level through the command
 * ##### clamp-levels
-    - **default**: true
+    - **default**: false
     - **description**: Setting this to `false` allows levels to go up to `32767` by storing them as shorts instead of bytes.
 
 ???+ note "Note"


### PR DESCRIPTION
In the default generated purpur.yml configuration file for version 1.21.3#2332 and 1.21.1#2329, this option should be set to false.